### PR TITLE
Inconsistent use of strings vs nameof() for specifying action method …

### DIFF
--- a/src/AlpineSkiHouse.Web/Controllers/SkiCardController.cs
+++ b/src/AlpineSkiHouse.Web/Controllers/SkiCardController.cs
@@ -144,7 +144,7 @@ namespace AlpineSkiHouse.Web.Controllers
 
                 await _skiCardContext.SaveChangesAsync();
 
-                return RedirectToAction("Index");
+                return RedirectToAction(nameof(Index));
             }            
             return View(viewModel);
         }


### PR DESCRIPTION
…names
