### PR TITLE
Add support for webjob

### DIFF
--- a/AlpineSkiHouse.sln
+++ b/AlpineSkiHouse.sln
@@ -12,6 +12,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 EndProject
 Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "AlpineSkiHouse.Web.Test", "test\AlpineSkiHouse.Web.Test\AlpineSkiHouse.Web.Test.xproj", "{C47DD736-721B-4E16-8255-6AF6B3FD2307}"
 EndProject
+Project("{8BB2217D-0F2D-49D1-97BC-3654ED321F3B}") = "AlpineSkiHouse.WebJobs", "src\AlpineSkiHouse.WebJobs\AlpineSkiHouse.WebJobs.xproj", "{81C7D405-C676-480C-88AA-9A270D28D903}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -26,6 +28,10 @@ Global
 		{C47DD736-721B-4E16-8255-6AF6B3FD2307}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C47DD736-721B-4E16-8255-6AF6B3FD2307}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C47DD736-721B-4E16-8255-6AF6B3FD2307}.Release|Any CPU.Build.0 = Release|Any CPU
+		{81C7D405-C676-480C-88AA-9A270D28D903}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{81C7D405-C676-480C-88AA-9A270D28D903}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{81C7D405-C676-480C-88AA-9A270D28D903}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{81C7D405-C676-480C-88AA-9A270D28D903}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/AlpineSkiHouse.Web/Controllers/SkiCardController.cs
+++ b/src/AlpineSkiHouse.Web/Controllers/SkiCardController.cs
@@ -104,7 +104,7 @@ namespace AlpineSkiHouse.Web.Controllers
                 {
                     _logger.LogInformation($"Uploading ski card image for {userId}");
                     imageId = Guid.NewGuid();
-                    var imageUri = await _uploadservice.UploadFileFromStream("cardimages", imageId.ToString(), viewModel.CardImage.OpenReadStream());
+                    var imageUri = await _uploadservice.UploadFileFromStream("cardimages", $"{imageId}.jpg", viewModel.CardImage.OpenReadStream());
                 }
 
                 _logger.LogInformation($"Saving ski card to DB for {userId}");

--- a/src/AlpineSkiHouse.Web/Events/SkiCardImageUploaded.cs
+++ b/src/AlpineSkiHouse.Web/Events/SkiCardImageUploaded.cs
@@ -8,6 +8,6 @@ namespace AlpineSkiHouse.Events
 {
     public class SkiCardImageUploaded : IAsyncNotification
     {
-        public string FileUri { get; set; }
+        public string FileName { get; set; }
     }
 }

--- a/src/AlpineSkiHouse.Web/Handlers/QueueResizeOnSkiCardImageUploadedHandler.cs
+++ b/src/AlpineSkiHouse.Web/Handlers/QueueResizeOnSkiCardImageUploadedHandler.cs
@@ -33,11 +33,10 @@ namespace AlpineSkiHouse.Handlers
             await imageQueue.CreateIfNotExistsAsync();
 
             // prepare and send the message to the queue
-            var messageBody = JsonConvert.SerializeObject(notification);
-            var message = new CloudQueueMessage(messageBody);
+            var message = new CloudQueueMessage(notification.FileName);
             await imageQueue.AddMessageAsync(message);
 
-            _logger.LogInformation($"Published image uploaded message for {notification.FileUri} to queue.");
+            _logger.LogInformation($"Published image uploaded message for {notification.FileName} to queue.");
         }
     }
 }

--- a/src/AlpineSkiHouse.Web/Services/BlobFileUploadService.cs
+++ b/src/AlpineSkiHouse.Web/Services/BlobFileUploadService.cs
@@ -40,9 +40,8 @@ namespace AlpineSkiHouse.Services
             _logger.LogInformation($"Ski card image uploaded as {targetFilename}");
 
             // publish event that image was uploaded
-            var blobUri = blob?.Uri.ToString();
-            await _bus.PublishAsync(new SkiCardImageUploaded { FileUri = blobUri });
-            return blobUri;
+            await _bus.PublishAsync(new SkiCardImageUploaded { FileName = targetFilename });
+            return blob?.Uri.ToString();
         }
 
     }

--- a/src/AlpineSkiHouse.WebJobs/AlpineSkiHouse.WebJobs.xproj
+++ b/src/AlpineSkiHouse.WebJobs/AlpineSkiHouse.WebJobs.xproj
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">14.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+  </PropertyGroup>
+
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.Props" Condition="'$(VSToolsPath)' != ''" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>81c7d405-c676-480c-88aa-9a270d28d903</ProjectGuid>
+    <RootNamespace>AlpineSkiHouse.WebJobs</RootNamespace>
+    <BaseIntermediateOutputPath Condition="'$(BaseIntermediateOutputPath)'=='' ">.\obj</BaseIntermediateOutputPath>
+    <OutputPath Condition="'$(OutputPath)'=='' ">.\bin\</OutputPath>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <Import Project="$(VSToolsPath)\DotNet\Microsoft.DotNet.targets" Condition="'$(VSToolsPath)' != ''" />
+</Project>

--- a/src/AlpineSkiHouse.WebJobs/Program.cs
+++ b/src/AlpineSkiHouse.WebJobs/Program.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
+using Microsoft.WindowsAzure.Storage;
+using Newtonsoft.Json.Linq;
+using ImageProcessorCore;
+using Microsoft.Azure.WebJobs;
+
+namespace AlpineSkiHouse.WebJobs
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            JobHost host = new JobHost();
+            host.RunAndBlock();
+        }
+    }
+}

--- a/src/AlpineSkiHouse.WebJobs/Properties/AssemblyInfo.cs
+++ b/src/AlpineSkiHouse.WebJobs/Properties/AssemblyInfo.cs
@@ -1,0 +1,19 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("AlpineSkiHouse.WebJobs")]
+[assembly: AssemblyTrademark("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("81c7d405-c676-480c-88aa-9a270d28d903")]

--- a/src/AlpineSkiHouse.WebJobs/WebJobs/ImageAdjustmentJob.cs
+++ b/src/AlpineSkiHouse.WebJobs/WebJobs/ImageAdjustmentJob.cs
@@ -1,0 +1,27 @@
+﻿using ImageProcessorCore;
+using Microsoft.Azure.WebJobs;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace AlpineSkiHouse.WebJobs.WebJobs
+{
+    public class ImageAdjustments
+    {
+        public static void ResizeAndGrayscaleImage(
+            [QueueTrigger("skicard-imageprocessing")] string message,
+            [Blob("cardimages/{queueTrigger}", FileAccess.Read)] Stream imageStream,
+            [Blob("processed/{queueTrigger}", FileAccess.Write)] Stream resizedImageStream)
+        {
+            var image = new Image(imageStream);
+
+            var resizedImage = image
+                .Resize(100, 0)
+                .Grayscale(GrayscaleMode.Bt709);
+
+            resizedImage.SaveAsJpeg(resizedImageStream);
+        }
+    }
+}

--- a/src/AlpineSkiHouse.WebJobs/project.json
+++ b/src/AlpineSkiHouse.WebJobs/project.json
@@ -1,0 +1,21 @@
+{
+  "version": "1.0.0-*",
+  "buildOptions": {
+    "emitEntryPoint": true
+  },
+
+  "dependencies": {
+    "ImageProcessorCore": "1.0.0-alpha1058",
+    "Microsoft.Azure.WebJobs": "2.0.0-beta1",
+    "Microsoft.Extensions.Configuration.Json": "1.0.0",
+    "Microsoft.Extensions.Configuration": "1.0.0",
+    "Microsoft.Extensions.Configuration.UserSecrets": "1.0.0",
+    "Newtonsoft.Json": "9.0.1",
+    "WindowsAzure.Storage": "7.2.1"
+  },
+
+  "frameworks": {
+    "net451": {}
+  },
+  "userSecretsId": "aspnet-AlpineSkiHouse.WebJobs-20161008073219"
+}

--- a/src/nuget.config
+++ b/src/nuget.config
@@ -1,0 +1,5 @@
+<configuration>
+  <packageSources>
+    <add key="imageprocessor" value="https://www.myget.org/F/imageprocessor/api/v3/index.json" />
+  </packageSources>
+</configuration>


### PR DESCRIPTION
This will take an uploaded profile image and upload it to blob storage. It then sends a message to the queue that an image is ready for processing. The webjob is triggered from the queue message, then kicks off to resize the image to 100x100 and change it to grayscale, then save it in the processed directory.

![image](https://cloud.githubusercontent.com/assets/1197383/19222882/7a58cfa0-8e28-11e6-8e45-c8019d6c6eef.png)

To do later:
- add config for max polling interval
- resize to outer bounding box instead of fixed size
- add code to show image on the skicard profile
