### PR TITLE
Fix web project build with dotnet build command

### DIFF
--- a/src/AlpineSkiHouse.Web/AlpineSkiHouse.Web.csproj
+++ b/src/AlpineSkiHouse.Web/AlpineSkiHouse.Web.csproj
@@ -7,6 +7,7 @@
     <OutputType>Exe</OutputType>
     <PackageId>AlpineSkiHouse.Web</PackageId>
     <UserSecretsId>aspnet-AlpineSkiHouse-4c485a7e-b4ac-4816-8cf5-4e2568b8f069</UserSecretsId>
+    <RuntimeFrameworkVersion>1.0.4</RuntimeFrameworkVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/AlpineSkiHouse.Web/AlpineSkiHouse.Web.csproj
+++ b/src/AlpineSkiHouse.Web/AlpineSkiHouse.Web.csproj
@@ -7,7 +7,6 @@
     <OutputType>Exe</OutputType>
     <PackageId>AlpineSkiHouse.Web</PackageId>
     <UserSecretsId>aspnet-AlpineSkiHouse-4c485a7e-b4ac-4816-8cf5-4e2568b8f069</UserSecretsId>
-    <RuntimeFrameworkVersion>1.0.4</RuntimeFrameworkVersion>
     <PackageTargetFallback>$(PackageTargetFallback);dotnet5.6;portable-net45+win8</PackageTargetFallback>
   </PropertyGroup>
 

--- a/src/AlpineSkiHouse.Web/AlpineSkiHouse.Web.csproj
+++ b/src/AlpineSkiHouse.Web/AlpineSkiHouse.Web.csproj
@@ -7,7 +7,6 @@
     <OutputType>Exe</OutputType>
     <PackageId>AlpineSkiHouse.Web</PackageId>
     <UserSecretsId>aspnet-AlpineSkiHouse-4c485a7e-b4ac-4816-8cf5-4e2568b8f069</UserSecretsId>
-    <PackageTargetFallback>$(PackageTargetFallback);dotnet5.6;portable-net45+win8</PackageTargetFallback>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Web project can't be built with `dotnet build` command, which doesn't allow to use `dotnet ef` commands when migrating database

**PackageTargetFallback** -  `dotnet build` returns
```
C:\workspace\github.com\kira-lappo\AlpineSkiHouse\src\AlpineSkiHouse.Web\AlpineSkiHouse.Web.csproj : error NU1003: PackageTargetFallback and AssetTargetFallback cannot be used together. Remove PackageTargetFallback(deprecated) references from the project environment.
```
**Solution** - remove `PackageTargetFallback` from namespace `AlpineSkiHouse.Web.csproj`